### PR TITLE
Add Super Display font control and fix styling for all font size levels

### DIFF
--- a/dist/css/block-editor-rtl.css
+++ b/dist/css/block-editor-rtl.css
@@ -217,6 +217,7 @@
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --current-font-weight: 800;
   --current-line-height: 1.2; }
 
@@ -251,6 +252,7 @@
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     --font-size: calc(var(--theme-header-logo-height-setting) * 1.8);
     --current-line-height: 1; }
     @media not screen and (min-width: 768px) {
@@ -709,6 +711,7 @@
       --current-font-weight: var(--theme-heading-1-font-weight);
       --current-letter-spacing: var(--theme-heading-1-letter-spacing);
       --current-text-transform: var(--theme-heading-1-text-transform);
+      --current-color: var(--theme-heading-1-color);
       --current-font-feature: "liga", "dlig", "onum"; }
     .editor-styles-wrapper[class] h2, .editor-styles-wrapper[class] .h2 {
       --font-size: var(--theme-heading-2-font-size);
@@ -719,6 +722,7 @@
       --current-line-height: var(--theme-heading-2-line-height);
       --current-letter-spacing: var(--theme-heading-2-letter-spacing);
       --current-text-transform: var(--theme-heading-2-text-transform);
+      --current-color: var(--theme-heading-2-color);
       --current-font-feature: "liga", "dlig", "onum"; }
     .editor-styles-wrapper[class] h3, .editor-styles-wrapper[class] .h3 {
       --font-size: var(--theme-heading-3-font-size);
@@ -728,7 +732,8 @@
       --current-font-weight: var(--theme-heading-3-font-weight);
       --current-line-height: var(--theme-heading-3-line-height);
       --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-      --current-text-transform: var(--theme-heading-3-text-transform); }
+      --current-text-transform: var(--theme-heading-3-text-transform);
+      --current-color: var(--theme-heading-3-color); }
     .editor-styles-wrapper[class] h4, .editor-styles-wrapper[class] .h4 {
       --font-size: var(--theme-heading-4-font-size);
       --current-font-size: var(--final-font-size);
@@ -737,7 +742,8 @@
       --current-font-style: var(--theme-heading-4-font-style);
       --current-line-height: var(--theme-heading-4-line-height);
       --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-      --current-text-transform: var(--theme-heading-4-text-transform); }
+      --current-text-transform: var(--theme-heading-4-text-transform);
+      --current-color: var(--theme-heading-4-color); }
     .editor-styles-wrapper[class] h5, .editor-styles-wrapper[class] .h5 {
       --font-size: var(--theme-heading-5-font-size);
       --current-font-size: var(--final-font-size);
@@ -746,7 +752,8 @@
       --current-font-style: var(--theme-heading-5-font-style);
       --current-line-height: var(--theme-heading-5-line-height);
       --current-letter-spacing: var(--theme-heading-5-letter-spacing);
-      --current-text-transform: var(--theme-heading-5-text-transform); }
+      --current-text-transform: var(--theme-heading-5-text-transform);
+      --current-color: var(--theme-heading-5-color); }
     .editor-styles-wrapper[class] h6, .editor-styles-wrapper[class] .h6 {
       --font-size: var(--theme-heading-6-font-size);
       --current-font-size: var(--final-font-size);
@@ -755,7 +762,8 @@
       --current-font-style: var(--theme-heading-6-font-style);
       --current-line-height: var(--theme-heading-6-line-height);
       --current-letter-spacing: var(--theme-heading-6-letter-spacing);
-      --current-text-transform: var(--theme-heading-6-text-transform); }
+      --current-text-transform: var(--theme-heading-6-text-transform);
+      --current-color: var(--theme-heading-6-color); }
     .editor-styles-wrapper[class] em,
     .editor-styles-wrapper[class] i,
     .editor-styles-wrapper[class] q,

--- a/dist/css/block-editor.css
+++ b/dist/css/block-editor.css
@@ -217,6 +217,7 @@
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --current-font-weight: 800;
   --current-line-height: 1.2; }
 
@@ -251,6 +252,7 @@
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     --font-size: calc(var(--theme-header-logo-height-setting) * 1.8);
     --current-line-height: 1; }
     @media not screen and (min-width: 768px) {
@@ -709,6 +711,7 @@
       --current-font-weight: var(--theme-heading-1-font-weight);
       --current-letter-spacing: var(--theme-heading-1-letter-spacing);
       --current-text-transform: var(--theme-heading-1-text-transform);
+      --current-color: var(--theme-heading-1-color);
       --current-font-feature: "liga", "dlig", "onum"; }
     .editor-styles-wrapper[class] h2, .editor-styles-wrapper[class] .h2 {
       --font-size: var(--theme-heading-2-font-size);
@@ -719,6 +722,7 @@
       --current-line-height: var(--theme-heading-2-line-height);
       --current-letter-spacing: var(--theme-heading-2-letter-spacing);
       --current-text-transform: var(--theme-heading-2-text-transform);
+      --current-color: var(--theme-heading-2-color);
       --current-font-feature: "liga", "dlig", "onum"; }
     .editor-styles-wrapper[class] h3, .editor-styles-wrapper[class] .h3 {
       --font-size: var(--theme-heading-3-font-size);
@@ -728,7 +732,8 @@
       --current-font-weight: var(--theme-heading-3-font-weight);
       --current-line-height: var(--theme-heading-3-line-height);
       --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-      --current-text-transform: var(--theme-heading-3-text-transform); }
+      --current-text-transform: var(--theme-heading-3-text-transform);
+      --current-color: var(--theme-heading-3-color); }
     .editor-styles-wrapper[class] h4, .editor-styles-wrapper[class] .h4 {
       --font-size: var(--theme-heading-4-font-size);
       --current-font-size: var(--final-font-size);
@@ -737,7 +742,8 @@
       --current-font-style: var(--theme-heading-4-font-style);
       --current-line-height: var(--theme-heading-4-line-height);
       --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-      --current-text-transform: var(--theme-heading-4-text-transform); }
+      --current-text-transform: var(--theme-heading-4-text-transform);
+      --current-color: var(--theme-heading-4-color); }
     .editor-styles-wrapper[class] h5, .editor-styles-wrapper[class] .h5 {
       --font-size: var(--theme-heading-5-font-size);
       --current-font-size: var(--final-font-size);
@@ -746,7 +752,8 @@
       --current-font-style: var(--theme-heading-5-font-style);
       --current-line-height: var(--theme-heading-5-line-height);
       --current-letter-spacing: var(--theme-heading-5-letter-spacing);
-      --current-text-transform: var(--theme-heading-5-text-transform); }
+      --current-text-transform: var(--theme-heading-5-text-transform);
+      --current-color: var(--theme-heading-5-color); }
     .editor-styles-wrapper[class] h6, .editor-styles-wrapper[class] .h6 {
       --font-size: var(--theme-heading-6-font-size);
       --current-font-size: var(--final-font-size);
@@ -755,7 +762,8 @@
       --current-font-style: var(--theme-heading-6-font-style);
       --current-line-height: var(--theme-heading-6-line-height);
       --current-letter-spacing: var(--theme-heading-6-letter-spacing);
-      --current-text-transform: var(--theme-heading-6-text-transform); }
+      --current-text-transform: var(--theme-heading-6-text-transform);
+      --current-color: var(--theme-heading-6-color); }
     .editor-styles-wrapper[class] em,
     .editor-styles-wrapper[class] i,
     .editor-styles-wrapper[class] q,

--- a/dist/css/blocks/common-rtl.css
+++ b/dist/css/blocks/common-rtl.css
@@ -1090,7 +1090,8 @@ html:root {
   --current-font-weight: var(--theme-heading-3-font-weight);
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-  --current-text-transform: var(--theme-heading-3-text-transform); }
+  --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color); }
 
 .wp-block-pullquote:before {
   content: "";

--- a/dist/css/blocks/common.css
+++ b/dist/css/blocks/common.css
@@ -1090,7 +1090,8 @@ html:root {
   --current-font-weight: var(--theme-heading-3-font-weight);
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-  --current-text-transform: var(--theme-heading-3-text-transform); }
+  --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color); }
 
 .wp-block-pullquote:before {
   content: "";

--- a/dist/css/blocks/editor-rtl.css
+++ b/dist/css/blocks/editor-rtl.css
@@ -361,6 +361,7 @@ ol[data-nb="list"] {
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     padding-left: var(--theme-spacing-tiny); }
   .nova-food-menu-item__title:before {
     bottom: 0.5em; }
@@ -377,7 +378,8 @@ ol[data-nb="list"] {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .nova-food-menu-item__title {
   font-size: var(--theme-heading-4-font-size); }

--- a/dist/css/blocks/editor.css
+++ b/dist/css/blocks/editor.css
@@ -361,6 +361,7 @@ ol[data-nb="list"] {
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     padding-right: var(--theme-spacing-tiny); }
   .nova-food-menu-item__title:before {
     bottom: 0.5em; }
@@ -377,7 +378,8 @@ ol[data-nb="list"] {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .nova-food-menu-item__title {
   font-size: var(--theme-heading-4-font-size); }

--- a/dist/css/blocks/nova-blocks/conversations-rtl.css
+++ b/dist/css/blocks/nova-blocks/conversations-rtl.css
@@ -251,7 +251,8 @@ trix-editor h1 {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 trix-editor,
 trix-toolbar {

--- a/dist/css/blocks/nova-blocks/conversations.css
+++ b/dist/css/blocks/nova-blocks/conversations.css
@@ -251,7 +251,8 @@ trix-editor h1 {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 trix-editor,
 trix-toolbar {

--- a/dist/css/blocks/style-rtl.css
+++ b/dist/css/blocks/style-rtl.css
@@ -430,6 +430,7 @@ ol.nb-list {
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     padding-left: var(--theme-spacing-tiny); }
   .nova-food-menu-item__title:before {
     bottom: 0.5em; }
@@ -446,7 +447,8 @@ ol.nb-list {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .nova-food-menu-item__title {
   font-size: var(--theme-heading-4-font-size); }

--- a/dist/css/blocks/style.css
+++ b/dist/css/blocks/style.css
@@ -430,6 +430,7 @@ ol.nb-list {
     --current-line-height: var(--theme-heading-4-line-height);
     --current-letter-spacing: var(--theme-heading-4-letter-spacing);
     --current-text-transform: var(--theme-heading-4-text-transform);
+    --current-color: var(--theme-heading-4-color);
     padding-right: var(--theme-spacing-tiny); }
   .nova-food-menu-item__title:before {
     bottom: 0.5em; }
@@ -446,7 +447,8 @@ ol.nb-list {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .nova-food-menu-item__title {
   font-size: var(--theme-heading-4-font-size); }

--- a/dist/css/custom-properties-rtl.css
+++ b/dist/css/custom-properties-rtl.css
@@ -37,6 +37,7 @@
   --theme-super-display-font-weight: 700;
   --theme-super-display-letter-spacing: -0.03em;
   --theme-super-display-text-transform: none;
+  --theme-super-display-color: var(--sm-current-fg2-color);
   --theme-display-font-family: Reforma1969, sans-serif;
   --theme-display-font-size: 115;
   --theme-display-font-style: normal;
@@ -44,6 +45,7 @@
   --theme-display-font-weight: 700;
   --theme-display-letter-spacing: -0.03em;
   --theme-display-text-transform: none;
+  --theme-display-color: var(--sm-current-fg2-color);
   --theme-heading-1-font-family: Reforma1969, sans-serif;
   --theme-heading-1-font-size: 66;
   --theme-heading-1-font-style: normal;
@@ -51,6 +53,7 @@
   --theme-heading-1-font-weight: 700;
   --theme-heading-1-letter-spacing: -0.03em;
   --theme-heading-1-text-transform: none;
+  --theme-heading-1-color: var(--sm-current-fg2-color);
   --theme-heading-2-font-family: Reforma1969, sans-serif;
   --theme-heading-2-font-size: 40;
   --theme-heading-2-font-style: normal;
@@ -58,6 +61,7 @@
   --theme-heading-2-line-height: 1.2;
   --theme-heading-2-letter-spacing: -0.02em;
   --theme-heading-2-text-transform: none;
+  --theme-heading-2-color: var(--sm-current-fg2-color);
   --theme-heading-3-font-family: Reforma1969, sans-serif;
   --theme-heading-3-font-size: 32;
   --theme-heading-3-font-style: normal;
@@ -65,6 +69,7 @@
   --theme-heading-3-line-height: 1.2;
   --theme-heading-3-letter-spacing: -0.02em;
   --theme-heading-3-text-transform: none;
+  --theme-heading-3-color: var(--sm-current-fg2-color);
   --theme-heading-4-font-family: Reforma1969, sans-serif;
   --theme-heading-4-font-size: 24;
   --theme-heading-4-font-weight: 700;
@@ -72,6 +77,7 @@
   --theme-heading-4-line-height: 1.2;
   --theme-heading-4-letter-spacing: -0.02em;
   --theme-heading-4-text-transform: none;
+  --theme-heading-4-color: var(--sm-current-fg2-color);
   --theme-heading-5-font-family: Reforma2018, sans-serif;
   --theme-heading-5-font-size: 17;
   --theme-heading-5-font-weight: 700;
@@ -79,6 +85,7 @@
   --theme-heading-5-line-height: 1.5;
   --theme-heading-5-letter-spacing: 0.017em;
   --theme-heading-5-text-transform: none;
+  --theme-heading-5-color: var(--sm-current-fg2-color);
   --theme-heading-6-font-family: Reforma2018, sans-serif;
   --theme-heading-6-font-size: 17;
   --theme-heading-6-font-weight: 500;
@@ -86,6 +93,7 @@
   --theme-heading-6-line-height: 1.5;
   --theme-heading-6-letter-spacing: 0.017em;
   --theme-heading-6-text-transform: none;
+  --theme-heading-6-color: var(--sm-current-fg2-color);
   --theme-navigation-font-family: Reforma2018, sans-serif;
   --theme-navigation-font-size: 17;
   --theme-navigation-font-weight: 500;
@@ -143,7 +151,8 @@
   font-style: var(--current-font-style);
   letter-spacing: var(--current-letter-spacing);
   text-transform: var(--current-text-transform);
-  font-feature-settings: var(--current-font-feature); }
+  font-feature-settings: var(--current-font-feature);
+  color: var(--current-color); }
 
 :root {
   --theme-content-width-wide-addon: var(--sm-site-container-width, 75);

--- a/dist/css/custom-properties-rtl.css
+++ b/dist/css/custom-properties-rtl.css
@@ -30,6 +30,13 @@
   --theme-caption-font-weight: normal;
   --theme-caption-line-height: 1.6;
   --theme-caption-letter-spacing: -0.03em;
+  --theme-super-display-font-family: Reforma1969, sans-serif;
+  --theme-super-display-font-size: 180;
+  --theme-super-display-font-style: normal;
+  --theme-super-display-line-height: 1.03;
+  --theme-super-display-font-weight: 700;
+  --theme-super-display-letter-spacing: -0.03em;
+  --theme-super-display-text-transform: none;
   --theme-display-font-family: Reforma1969, sans-serif;
   --theme-display-font-size: 115;
   --theme-display-font-style: normal;

--- a/dist/css/custom-properties.css
+++ b/dist/css/custom-properties.css
@@ -37,6 +37,7 @@
   --theme-super-display-font-weight: 700;
   --theme-super-display-letter-spacing: -0.03em;
   --theme-super-display-text-transform: none;
+  --theme-super-display-color: var(--sm-current-fg2-color);
   --theme-display-font-family: Reforma1969, sans-serif;
   --theme-display-font-size: 115;
   --theme-display-font-style: normal;
@@ -44,6 +45,7 @@
   --theme-display-font-weight: 700;
   --theme-display-letter-spacing: -0.03em;
   --theme-display-text-transform: none;
+  --theme-display-color: var(--sm-current-fg2-color);
   --theme-heading-1-font-family: Reforma1969, sans-serif;
   --theme-heading-1-font-size: 66;
   --theme-heading-1-font-style: normal;
@@ -51,6 +53,7 @@
   --theme-heading-1-font-weight: 700;
   --theme-heading-1-letter-spacing: -0.03em;
   --theme-heading-1-text-transform: none;
+  --theme-heading-1-color: var(--sm-current-fg2-color);
   --theme-heading-2-font-family: Reforma1969, sans-serif;
   --theme-heading-2-font-size: 40;
   --theme-heading-2-font-style: normal;
@@ -58,6 +61,7 @@
   --theme-heading-2-line-height: 1.2;
   --theme-heading-2-letter-spacing: -0.02em;
   --theme-heading-2-text-transform: none;
+  --theme-heading-2-color: var(--sm-current-fg2-color);
   --theme-heading-3-font-family: Reforma1969, sans-serif;
   --theme-heading-3-font-size: 32;
   --theme-heading-3-font-style: normal;
@@ -65,6 +69,7 @@
   --theme-heading-3-line-height: 1.2;
   --theme-heading-3-letter-spacing: -0.02em;
   --theme-heading-3-text-transform: none;
+  --theme-heading-3-color: var(--sm-current-fg2-color);
   --theme-heading-4-font-family: Reforma1969, sans-serif;
   --theme-heading-4-font-size: 24;
   --theme-heading-4-font-weight: 700;
@@ -72,6 +77,7 @@
   --theme-heading-4-line-height: 1.2;
   --theme-heading-4-letter-spacing: -0.02em;
   --theme-heading-4-text-transform: none;
+  --theme-heading-4-color: var(--sm-current-fg2-color);
   --theme-heading-5-font-family: Reforma2018, sans-serif;
   --theme-heading-5-font-size: 17;
   --theme-heading-5-font-weight: 700;
@@ -79,6 +85,7 @@
   --theme-heading-5-line-height: 1.5;
   --theme-heading-5-letter-spacing: 0.017em;
   --theme-heading-5-text-transform: none;
+  --theme-heading-5-color: var(--sm-current-fg2-color);
   --theme-heading-6-font-family: Reforma2018, sans-serif;
   --theme-heading-6-font-size: 17;
   --theme-heading-6-font-weight: 500;
@@ -86,6 +93,7 @@
   --theme-heading-6-line-height: 1.5;
   --theme-heading-6-letter-spacing: 0.017em;
   --theme-heading-6-text-transform: none;
+  --theme-heading-6-color: var(--sm-current-fg2-color);
   --theme-navigation-font-family: Reforma2018, sans-serif;
   --theme-navigation-font-size: 17;
   --theme-navigation-font-weight: 500;
@@ -143,7 +151,8 @@
   font-style: var(--current-font-style);
   letter-spacing: var(--current-letter-spacing);
   text-transform: var(--current-text-transform);
-  font-feature-settings: var(--current-font-feature); }
+  font-feature-settings: var(--current-font-feature);
+  color: var(--current-color); }
 
 :root {
   --theme-content-width-wide-addon: var(--sm-site-container-width, 75);

--- a/dist/css/custom-properties.css
+++ b/dist/css/custom-properties.css
@@ -30,6 +30,13 @@
   --theme-caption-font-weight: normal;
   --theme-caption-line-height: 1.6;
   --theme-caption-letter-spacing: -0.03em;
+  --theme-super-display-font-family: Reforma1969, sans-serif;
+  --theme-super-display-font-size: 180;
+  --theme-super-display-font-style: normal;
+  --theme-super-display-line-height: 1.03;
+  --theme-super-display-font-weight: 700;
+  --theme-super-display-letter-spacing: -0.03em;
+  --theme-super-display-text-transform: none;
   --theme-display-font-family: Reforma1969, sans-serif;
   --theme-display-font-size: 115;
   --theme-display-font-style: normal;

--- a/dist/css/utility-rtl.css
+++ b/dist/css/utility-rtl.css
@@ -509,6 +509,7 @@
   --current-font-weight: var(--theme-super-display-font-weight);
   --current-letter-spacing: var(--theme-super-display-letter-spacing);
   --current-text-transform: var(--theme-super-display-text-transform);
+  --current-color: var(--theme-super-display-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-larger-font-size,
@@ -521,6 +522,7 @@
   --current-font-weight: var(--theme-display-font-weight);
   --current-letter-spacing: var(--theme-display-letter-spacing);
   --current-text-transform: var(--theme-display-text-transform);
+  --current-color: var(--theme-display-color);
   --font-size-modifier: 1; }
 
 [class][class] h2.has-larger-font-size,
@@ -533,6 +535,7 @@
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-smaller-font-size,
@@ -545,6 +548,7 @@
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
   --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-smallest-font-size,
@@ -559,6 +563,7 @@
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
   --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color);
   --font-size-modifier: 1; }
 
 [class][class] h2.has-smallest-font-size,
@@ -573,6 +578,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   --font-size-modifier: 1; }
 
 [class][class] h3.has-smallest-font-size,
@@ -586,6 +592,7 @@
   --current-line-height: var(--theme-heading-5-line-height);
   --current-letter-spacing: var(--theme-heading-5-letter-spacing);
   --current-text-transform: var(--theme-heading-5-text-transform);
+  --current-color: var(--theme-heading-5-color);
   --font-size-modifier: 1; }
 
 [class][class] h4.has-smallest-font-size,
@@ -601,4 +608,5 @@
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
   --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color);
   --font-size-modifier: 1; }

--- a/dist/css/utility-rtl.css
+++ b/dist/css/utility-rtl.css
@@ -478,17 +478,41 @@
     .admin-bar {
       --admin-bar-height: 46px; } }
 
-[class][class] .has-smaller-font-size {
-  --font-size: inherit;
-  --font-size-modifier: 0.8;
+[class][class] .has-smallest-font-size,
+[class][class] .has-smaller-font-size,
+[class][class] .has-normal-font-size,
+[class][class] .has-larger-font-size,
+[class][class] .has-largest-font-size {
   font-size: var(--current-font-size); }
+
+[class][class] .has-smallest-font-size {
+  --font-size-modifier: 0.6; }
+
+[class][class] .has-smaller-font-size {
+  --font-size-modifier: 0.8; }
+
+[class][class] .has-normal-font-size {
+  --font-size-modifier: 1; }
 
 [class][class] .has-larger-font-size {
-  --font-size: inherit;
-  --font-size-modifier: 1.25;
-  font-size: var(--current-font-size); }
+  --font-size-modifier: 1.25; }
 
-[class][class] h1.has-larger-font-size {
+[class][class] .has-largest-font-size {
+  --font-size-modifier: 1.5; }
+
+[class][class] h1.has-largest-font-size {
+  --font-size: var(--theme-super-display-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-super-display-font-family);
+  --current-font-style: var(--theme-super-display-font-style);
+  --current-line-height: var(--theme-super-display-line-height);
+  --current-font-weight: var(--theme-super-display-font-weight);
+  --current-letter-spacing: var(--theme-super-display-letter-spacing);
+  --current-text-transform: var(--theme-super-display-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h1.has-larger-font-size,
+[class][class] h2.has-largest-font-size {
   --font-size: var(--theme-display-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-display-font-family);
@@ -499,7 +523,8 @@
   --current-text-transform: var(--theme-display-text-transform);
   --font-size-modifier: 1; }
 
-[class][class] h2.has-larger-font-size {
+[class][class] h2.has-larger-font-size,
+[class][class] h3.has-largest-font-size {
   --font-size: var(--theme-heading-1-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-1-font-family);
@@ -522,8 +547,10 @@
   --current-text-transform: var(--theme-heading-2-text-transform);
   --font-size-modifier: 1; }
 
+[class][class] h1.has-smallest-font-size,
 [class][class] h2.has-smaller-font-size,
-[class][class] h4.has-larger-font-size {
+[class][class] h4.has-larger-font-size,
+[class][class] h5.has-largest-font-size {
   --font-size: var(--theme-heading-3-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-3-font-family);
@@ -534,8 +561,10 @@
   --current-text-transform: var(--theme-heading-3-text-transform);
   --font-size-modifier: 1; }
 
+[class][class] h2.has-smallest-font-size,
 [class][class] h3.has-smaller-font-size,
-[class][class] h5.has-larger-font-size {
+[class][class] h5.has-larger-font-size,
+[class][class] h6.has-largest-font-size {
   --font-size: var(--theme-heading-4-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-4-font-family);
@@ -544,4 +573,32 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h3.has-smallest-font-size,
+[class][class] h4.has-smaller-font-size,
+[class][class] h6.has-larger-font-size {
+  --font-size: var(--theme-heading-5-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-heading-5-font-family);
+  --current-font-weight: var(--theme-heading-5-font-weight);
+  --current-font-style: var(--theme-heading-5-font-style);
+  --current-line-height: var(--theme-heading-5-line-height);
+  --current-letter-spacing: var(--theme-heading-5-letter-spacing);
+  --current-text-transform: var(--theme-heading-5-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h4.has-smallest-font-size,
+[class][class] h5.has-smaller-font-size,
+[class][class] h5.has-smallest-font-size,
+[class][class] h6.has-smaller-font-size,
+[class][class] h6.has-smallest-font-size {
+  --font-size: var(--theme-heading-6-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-heading-6-font-family);
+  --current-font-weight: var(--theme-heading-6-font-weight);
+  --current-font-style: var(--theme-heading-6-font-style);
+  --current-line-height: var(--theme-heading-6-line-height);
+  --current-letter-spacing: var(--theme-heading-6-letter-spacing);
+  --current-text-transform: var(--theme-heading-6-text-transform);
   --font-size-modifier: 1; }

--- a/dist/css/utility.css
+++ b/dist/css/utility.css
@@ -509,6 +509,7 @@
   --current-font-weight: var(--theme-super-display-font-weight);
   --current-letter-spacing: var(--theme-super-display-letter-spacing);
   --current-text-transform: var(--theme-super-display-text-transform);
+  --current-color: var(--theme-super-display-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-larger-font-size,
@@ -521,6 +522,7 @@
   --current-font-weight: var(--theme-display-font-weight);
   --current-letter-spacing: var(--theme-display-letter-spacing);
   --current-text-transform: var(--theme-display-text-transform);
+  --current-color: var(--theme-display-color);
   --font-size-modifier: 1; }
 
 [class][class] h2.has-larger-font-size,
@@ -533,6 +535,7 @@
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-smaller-font-size,
@@ -545,6 +548,7 @@
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
   --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color);
   --font-size-modifier: 1; }
 
 [class][class] h1.has-smallest-font-size,
@@ -559,6 +563,7 @@
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
   --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color);
   --font-size-modifier: 1; }
 
 [class][class] h2.has-smallest-font-size,
@@ -573,6 +578,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   --font-size-modifier: 1; }
 
 [class][class] h3.has-smallest-font-size,
@@ -586,6 +592,7 @@
   --current-line-height: var(--theme-heading-5-line-height);
   --current-letter-spacing: var(--theme-heading-5-letter-spacing);
   --current-text-transform: var(--theme-heading-5-text-transform);
+  --current-color: var(--theme-heading-5-color);
   --font-size-modifier: 1; }
 
 [class][class] h4.has-smallest-font-size,
@@ -601,4 +608,5 @@
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
   --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color);
   --font-size-modifier: 1; }

--- a/dist/css/utility.css
+++ b/dist/css/utility.css
@@ -478,17 +478,41 @@
     .admin-bar {
       --admin-bar-height: 46px; } }
 
-[class][class] .has-smaller-font-size {
-  --font-size: inherit;
-  --font-size-modifier: 0.8;
+[class][class] .has-smallest-font-size,
+[class][class] .has-smaller-font-size,
+[class][class] .has-normal-font-size,
+[class][class] .has-larger-font-size,
+[class][class] .has-largest-font-size {
   font-size: var(--current-font-size); }
+
+[class][class] .has-smallest-font-size {
+  --font-size-modifier: 0.6; }
+
+[class][class] .has-smaller-font-size {
+  --font-size-modifier: 0.8; }
+
+[class][class] .has-normal-font-size {
+  --font-size-modifier: 1; }
 
 [class][class] .has-larger-font-size {
-  --font-size: inherit;
-  --font-size-modifier: 1.25;
-  font-size: var(--current-font-size); }
+  --font-size-modifier: 1.25; }
 
-[class][class] h1.has-larger-font-size {
+[class][class] .has-largest-font-size {
+  --font-size-modifier: 1.5; }
+
+[class][class] h1.has-largest-font-size {
+  --font-size: var(--theme-super-display-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-super-display-font-family);
+  --current-font-style: var(--theme-super-display-font-style);
+  --current-line-height: var(--theme-super-display-line-height);
+  --current-font-weight: var(--theme-super-display-font-weight);
+  --current-letter-spacing: var(--theme-super-display-letter-spacing);
+  --current-text-transform: var(--theme-super-display-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h1.has-larger-font-size,
+[class][class] h2.has-largest-font-size {
   --font-size: var(--theme-display-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-display-font-family);
@@ -499,7 +523,8 @@
   --current-text-transform: var(--theme-display-text-transform);
   --font-size-modifier: 1; }
 
-[class][class] h2.has-larger-font-size {
+[class][class] h2.has-larger-font-size,
+[class][class] h3.has-largest-font-size {
   --font-size: var(--theme-heading-1-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-1-font-family);
@@ -522,8 +547,10 @@
   --current-text-transform: var(--theme-heading-2-text-transform);
   --font-size-modifier: 1; }
 
+[class][class] h1.has-smallest-font-size,
 [class][class] h2.has-smaller-font-size,
-[class][class] h4.has-larger-font-size {
+[class][class] h4.has-larger-font-size,
+[class][class] h5.has-largest-font-size {
   --font-size: var(--theme-heading-3-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-3-font-family);
@@ -534,8 +561,10 @@
   --current-text-transform: var(--theme-heading-3-text-transform);
   --font-size-modifier: 1; }
 
+[class][class] h2.has-smallest-font-size,
 [class][class] h3.has-smaller-font-size,
-[class][class] h5.has-larger-font-size {
+[class][class] h5.has-larger-font-size,
+[class][class] h6.has-largest-font-size {
   --font-size: var(--theme-heading-4-font-size);
   --current-font-size: var(--final-font-size);
   --current-font-family: var(--theme-heading-4-font-family);
@@ -544,4 +573,32 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h3.has-smallest-font-size,
+[class][class] h4.has-smaller-font-size,
+[class][class] h6.has-larger-font-size {
+  --font-size: var(--theme-heading-5-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-heading-5-font-family);
+  --current-font-weight: var(--theme-heading-5-font-weight);
+  --current-font-style: var(--theme-heading-5-font-style);
+  --current-line-height: var(--theme-heading-5-line-height);
+  --current-letter-spacing: var(--theme-heading-5-letter-spacing);
+  --current-text-transform: var(--theme-heading-5-text-transform);
+  --font-size-modifier: 1; }
+
+[class][class] h4.has-smallest-font-size,
+[class][class] h5.has-smaller-font-size,
+[class][class] h5.has-smallest-font-size,
+[class][class] h6.has-smaller-font-size,
+[class][class] h6.has-smallest-font-size {
+  --font-size: var(--theme-heading-6-font-size);
+  --current-font-size: var(--final-font-size);
+  --current-font-family: var(--theme-heading-6-font-family);
+  --current-font-weight: var(--theme-heading-6-font-weight);
+  --current-font-style: var(--theme-heading-6-font-style);
+  --current-line-height: var(--theme-heading-6-line-height);
+  --current-letter-spacing: var(--theme-heading-6-letter-spacing);
+  --current-text-transform: var(--theme-heading-6-text-transform);
   --font-size-modifier: 1; }

--- a/dist/css/woocommerce/block-editor-rtl.css
+++ b/dist/css/woocommerce/block-editor-rtl.css
@@ -258,7 +258,8 @@
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 [class][class][class] .wc-block-grid__product-link {
   --current-aspect-ratio: 1;

--- a/dist/css/woocommerce/block-editor.css
+++ b/dist/css/woocommerce/block-editor.css
@@ -258,7 +258,8 @@
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 [class][class][class] .wc-block-grid__product-link {
   --current-aspect-ratio: 1;

--- a/dist/css/woocommerce/style-rtl.css
+++ b/dist/css/woocommerce/style-rtl.css
@@ -828,6 +828,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   color: var(--sm-current-fg1-color);
   margin-top: var(--theme-spacing-tiny); }
 
@@ -1050,7 +1051,8 @@
     --current-font-weight: var(--theme-heading-3-font-weight);
     --current-line-height: var(--theme-heading-3-line-height);
     --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-    --current-text-transform: var(--theme-heading-3-text-transform); }
+    --current-text-transform: var(--theme-heading-3-text-transform);
+    --current-color: var(--theme-heading-3-color); }
   .c-product-main .price {
     margin-bottom: var(--theme-spacing-small); }
   .c-product-main span.onsale {
@@ -1360,7 +1362,8 @@
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .woocommerce #reviews #comments ol.commentlist {
   padding-right: 0; }
@@ -1990,6 +1993,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   margin-bottom: var(--theme-spacing); }
 
 [id="order_review_heading"] {
@@ -2052,7 +2056,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .cart_totals h2 {
   --font-size: var(--theme-heading-3-font-size);
@@ -2063,6 +2068,7 @@ ul.order_details[class] {
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
   --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color);
   margin-bottom: var(--theme-spacing-small); }
 
 .cross-sells h2 {
@@ -2074,6 +2080,7 @@ ul.order_details[class] {
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   margin-bottom: var(--theme-spacing-small); }
 
 #add_payment_method #payment div.payment_box,
@@ -2089,7 +2096,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
   #ship-to-different-address .woocommerce-form__label {
     display: flex;
     align-items: center; }
@@ -2194,7 +2202,8 @@ ul.order_details[class] {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .woocommerce-checkout-breadcrumbs li a {
   --current-font-weight: bold;
@@ -2214,7 +2223,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .cart-subtotal .woocommerce-Price-amount {
   --current-font-weight: bold; }
@@ -2647,7 +2657,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 [class][class][class] .wc-block-grid__product-link {
   --current-aspect-ratio: 1;

--- a/dist/css/woocommerce/style.css
+++ b/dist/css/woocommerce/style.css
@@ -828,6 +828,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   color: var(--sm-current-fg1-color);
   margin-top: var(--theme-spacing-tiny); }
 
@@ -1050,7 +1051,8 @@
     --current-font-weight: var(--theme-heading-3-font-weight);
     --current-line-height: var(--theme-heading-3-line-height);
     --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-    --current-text-transform: var(--theme-heading-3-text-transform); }
+    --current-text-transform: var(--theme-heading-3-text-transform);
+    --current-color: var(--theme-heading-3-color); }
   .c-product-main .price {
     margin-bottom: var(--theme-spacing-small); }
   .c-product-main span.onsale {
@@ -1360,7 +1362,8 @@
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .woocommerce #reviews #comments ol.commentlist {
   padding-left: 0; }
@@ -1990,6 +1993,7 @@
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   margin-bottom: var(--theme-spacing); }
 
 [id="order_review_heading"] {
@@ -2052,7 +2056,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .cart_totals h2 {
   --font-size: var(--theme-heading-3-font-size);
@@ -2063,6 +2068,7 @@ ul.order_details[class] {
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
   --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color);
   margin-bottom: var(--theme-spacing-small); }
 
 .cross-sells h2 {
@@ -2074,6 +2080,7 @@ ul.order_details[class] {
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   margin-bottom: var(--theme-spacing-small); }
 
 #add_payment_method #payment div.payment_box,
@@ -2089,7 +2096,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
   #ship-to-different-address .woocommerce-form__label {
     display: flex;
     align-items: center; }
@@ -2194,7 +2202,8 @@ ul.order_details[class] {
   --current-font-weight: var(--theme-heading-2-font-weight);
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
-  --current-text-transform: var(--theme-heading-2-text-transform); }
+  --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color); }
 
 .woocommerce-checkout-breadcrumbs li a {
   --current-font-weight: bold;
@@ -2214,7 +2223,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .cart-subtotal .woocommerce-Price-amount {
   --current-font-weight: bold; }
@@ -2647,7 +2657,8 @@ ul.order_details[class] {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 [class][class][class] .wc-block-grid__product-link {
   --current-aspect-ratio: 1;

--- a/inc/integrations/style-manager/colors.php
+++ b/inc/integrations/style-manager/colors.php
@@ -62,12 +62,14 @@ function pixelgrade_add_colors_section_to_style_manager_config( $config ) {
 				'html' => '<span class="sm-group__title">' . esc_html__( 'Headings', '__theme_txtd' ) . '</span>',
 			),
 
-			'heading_1_color' => sm_get_color_switch_darker_config( 'Heading 1', 'h1', false, 1 ),
-			'heading_2_color' => sm_get_color_switch_darker_config( 'Heading 2', 'h2', false, 1 ),
-			'heading_3_color' => sm_get_color_switch_darker_config( 'Heading 3', 'h3', false, 2 ),
-			'heading_4_color' => sm_get_color_switch_darker_config( 'Heading 4', 'h4', false, 2 ),
-			'heading_5_color' => sm_get_color_switch_darker_config( 'Heading 5', 'h5', false, 3 ),
-			'heading_6_color' => sm_get_color_switch_darker_config( 'Heading 6', 'h6', false, 3 ),
+			'super_display_color' => sm_get_color_switch_darker_config( 'Super Display', '*', false, 1, [ '--theme-super-display-color' ] ),
+			'display_color'       => sm_get_color_switch_darker_config( 'Display', '*', false, 1, [ '--theme-display-color' ] ),
+			'heading_1_color'     => sm_get_color_switch_darker_config( 'Heading 1', '*', false, 1, [ '--theme-heading-1-color' ] ),
+			'heading_2_color'     => sm_get_color_switch_darker_config( 'Heading 2', '*', false, 1, [ '--theme-heading-2-color' ] ),
+			'heading_3_color'     => sm_get_color_switch_darker_config( 'Heading 3', '*', false, 2, [ '--theme-heading-3-color' ] ),
+			'heading_4_color'     => sm_get_color_switch_darker_config( 'Heading 4', '*', false, 2, [ '--theme-heading-4-color' ] ),
+			'heading_5_color'     => sm_get_color_switch_darker_config( 'Heading 5', '*', false, 3, [ '--theme-heading-5-color' ] ),
+			'heading_6_color'     => sm_get_color_switch_darker_config( 'Heading 6', '*', false, 3, [ '--theme-heading-6-color' ] ),
 
 			'sm-group-separator-3' => array( 'type' => 'html', 'html' => '' ),
 

--- a/inc/integrations/style-manager/connected-fields.php
+++ b/inc/integrations/style-manager/connected-fields.php
@@ -29,6 +29,7 @@ function rosa2_add_style_manager_connected_fields( $options ) {
 				'sm_font_primary'    => array(
 					'default' => 'Reforma1969',
 					'connected_fields' => array(
+						'super_display_font',
 						'display_font',
 						'heading_1_font',
 						'heading_2_font',

--- a/inc/integrations/style-manager/fonts.php
+++ b/inc/integrations/style-manager/fonts.php
@@ -187,6 +187,23 @@ function rosa2_add_fonts_section_to_style_manager_config( $config ) {
 					'type' => 'html',
 					'html' => '<span class="separator sub-section label">' . esc_html__( 'Heading Fonts', '__theme_txtd' ) . '</span>',
 				),
+				'super_display_font'    => array(
+					'type'              => 'font',
+					'label'             => esc_html__( 'Super Display', '__theme_txtd' ),
+					'desc'              => esc_html__( '', '__theme_txtd' ),
+					'selector'          => ':root',
+					'properties_prefix' => '--theme-super-display-',
+					'default'           => array(
+						'font-family'     => 'Reforma1969',
+						'font-size'       => 180,
+						'line-height'     => 1.03,
+						'font-weight'     => 700,
+						'text-transform'  => 'none',
+						'text-decoration' => 'none',
+						'letter-spacing'  => - 0.03,
+					),
+					'fields'            => $fields_config_large,
+				),
 				'display_font'    => array(
 					'type'              => 'font',
 					'label'             => esc_html__( 'Display', '__theme_txtd' ),

--- a/src/scss/custom-properties/_typography.scss
+++ b/src/scss/custom-properties/_typography.scss
@@ -64,4 +64,6 @@
     letter-spacing: var(--current-letter-spacing);
     text-transform: var(--current-text-transform);
     font-feature-settings: var(--current-font-feature);
+
+    color: var(--current-color);
 }

--- a/src/scss/setup/_typography.scss
+++ b/src/scss/setup/_typography.scss
@@ -67,6 +67,7 @@ $theme-fonts: (
         font-weight: 700,
         letter-spacing: -0.03em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     display: (
         font-family: $theme-sm-font-primary,
@@ -76,6 +77,7 @@ $theme-fonts: (
         font-weight: 700,
         letter-spacing: -0.03em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-1: (
         font-family: $theme-sm-font-primary,
@@ -85,6 +87,7 @@ $theme-fonts: (
         font-weight: 700,
         letter-spacing: -0.03em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-2: (
         font-family: $theme-sm-font-primary,
@@ -94,6 +97,7 @@ $theme-fonts: (
         line-height: 1.2,
         letter-spacing: -0.02em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-3: (
         font-family: $theme-sm-font-primary,
@@ -103,6 +107,7 @@ $theme-fonts: (
         line-height: 1.2,
         letter-spacing: -0.02em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-4: (
         font-family: $theme-sm-font-primary,
@@ -112,6 +117,7 @@ $theme-fonts: (
         line-height: 1.2,
         letter-spacing: -0.02em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-5: (
         font-family: $theme-sm-font-secondary,
@@ -121,6 +127,7 @@ $theme-fonts: (
         line-height: 1.5,
         letter-spacing: 0.017em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     heading-6: (
         font-family: $theme-sm-font-secondary,
@@ -130,6 +137,7 @@ $theme-fonts: (
         line-height: 1.5,
         letter-spacing: 0.017em,
         text-transform: none,
+        color: var(--sm-current-fg2-color),
     ),
     navigation: (
         font-family: $theme-sm-font-secondary,

--- a/src/scss/setup/_typography.scss
+++ b/src/scss/setup/_typography.scss
@@ -59,6 +59,15 @@ $theme-fonts: (
         line-height: 1.6,
         letter-spacing: -0.03em
     ),
+    super-display: (
+        font-family: $theme-sm-font-primary,
+        font-size: 180,
+        font-style: normal,
+        line-height: 1.03,
+        font-weight: 700,
+        letter-spacing: -0.03em,
+        text-transform: none,
+    ),
     display: (
         font-family: $theme-sm-font-primary,
         font-size: 115,

--- a/src/scss/utility/_font-size.scss
+++ b/src/scss/utility/_font-size.scss
@@ -1,21 +1,44 @@
-.has-smaller-font-size {
-    --font-size: inherit;
-    --font-size-modifier: 0.8;
+.has-smallest-font-size,
+.has-smaller-font-size,
+.has-normal-font-size,
+.has-larger-font-size,
+.has-largest-font-size {
     font-size: var(--current-font-size);
+}
+
+.has-smallest-font-size {
+    --font-size-modifier: 0.6;
+}
+
+.has-smaller-font-size {
+    --font-size-modifier: 0.8;
+}
+
+.has-normal-font-size {
+    --font-size-modifier: 1;
 }
 
 .has-larger-font-size {
-    --font-size: inherit;
     --font-size-modifier: 1.25;
-    font-size: var(--current-font-size);
 }
 
-h1.has-larger-font-size {
+.has-largest-font-size {
+    --font-size-modifier: 1.5;
+}
+
+h1.has-largest-font-size {
+    @include apply-font(super-display);
+    --font-size-modifier: 1;
+}
+
+h1.has-larger-font-size,
+h2.has-largest-font-size {
     @include apply-font(display);
     --font-size-modifier: 1;
 }
 
-h2.has-larger-font-size {
+h2.has-larger-font-size,
+h3.has-largest-font-size {
     @include apply-font(heading-1);
     --font-size-modifier: 1;
 }
@@ -26,14 +49,34 @@ h3.has-larger-font-size {
     --font-size-modifier: 1;
 }
 
+h1.has-smallest-font-size,
 h2.has-smaller-font-size,
-h4.has-larger-font-size {
+h4.has-larger-font-size,
+h5.has-largest-font-size {
     @include apply-font(heading-3);
     --font-size-modifier: 1;
 }
 
+h2.has-smallest-font-size,
 h3.has-smaller-font-size,
-h5.has-larger-font-size {
+h5.has-larger-font-size,
+h6.has-largest-font-size {
     @include apply-font(heading-4);
+    --font-size-modifier: 1;
+}
+
+h3.has-smallest-font-size,
+h4.has-smaller-font-size,
+h6.has-larger-font-size {
+    @include apply-font(heading-5);
+    --font-size-modifier: 1;
+}
+
+h4.has-smallest-font-size,
+h5.has-smaller-font-size,
+h5.has-smallest-font-size,
+h6.has-smaller-font-size,
+h6.has-smallest-font-size {
+    @include apply-font(heading-6);
     --font-size-modifier: 1;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -768,6 +768,7 @@ h1, .h1 {
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --current-font-feature: "liga", "dlig", "onum"; }
 
 h2, .h2 {
@@ -779,6 +780,7 @@ h2, .h2 {
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
   --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color);
   --current-font-feature: "liga", "dlig", "onum"; }
 
 h3, .h3 {
@@ -789,7 +791,8 @@ h3, .h3 {
   --current-font-weight: var(--theme-heading-3-font-weight);
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-  --current-text-transform: var(--theme-heading-3-text-transform); }
+  --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color); }
 
 h4, .h4 {
   --font-size: var(--theme-heading-4-font-size);
@@ -799,7 +802,8 @@ h4, .h4 {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 h5, .h5 {
   --font-size: var(--theme-heading-5-font-size);
@@ -809,7 +813,8 @@ h5, .h5 {
   --current-font-style: var(--theme-heading-5-font-style);
   --current-line-height: var(--theme-heading-5-line-height);
   --current-letter-spacing: var(--theme-heading-5-letter-spacing);
-  --current-text-transform: var(--theme-heading-5-text-transform); }
+  --current-text-transform: var(--theme-heading-5-text-transform);
+  --current-color: var(--theme-heading-5-color); }
 
 h6, .h6 {
   --font-size: var(--theme-heading-6-font-size);
@@ -819,7 +824,8 @@ h6, .h6 {
   --current-font-style: var(--theme-heading-6-font-style);
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
-  --current-text-transform: var(--theme-heading-6-text-transform); }
+  --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color); }
 
 em,
 i,
@@ -1454,6 +1460,7 @@ table {
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   --font-size: calc(var(--theme-header-logo-height-setting) * 1.8);
   --current-line-height: 1; }
   @media not screen and (min-width: 768px) {
@@ -2044,6 +2051,7 @@ label.subscribe-label.subscribe-label {
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
   --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color);
   opacity: .6; }
 
 .comment__metadata {
@@ -2268,7 +2276,8 @@ span.page-numbers {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .post-navigation__post-title,
 .post-navigation__link-label {

--- a/style.css
+++ b/style.css
@@ -768,6 +768,7 @@ h1, .h1 {
   --current-font-weight: var(--theme-heading-1-font-weight);
   --current-letter-spacing: var(--theme-heading-1-letter-spacing);
   --current-text-transform: var(--theme-heading-1-text-transform);
+  --current-color: var(--theme-heading-1-color);
   --current-font-feature: "liga", "dlig", "onum"; }
 
 h2, .h2 {
@@ -779,6 +780,7 @@ h2, .h2 {
   --current-line-height: var(--theme-heading-2-line-height);
   --current-letter-spacing: var(--theme-heading-2-letter-spacing);
   --current-text-transform: var(--theme-heading-2-text-transform);
+  --current-color: var(--theme-heading-2-color);
   --current-font-feature: "liga", "dlig", "onum"; }
 
 h3, .h3 {
@@ -789,7 +791,8 @@ h3, .h3 {
   --current-font-weight: var(--theme-heading-3-font-weight);
   --current-line-height: var(--theme-heading-3-line-height);
   --current-letter-spacing: var(--theme-heading-3-letter-spacing);
-  --current-text-transform: var(--theme-heading-3-text-transform); }
+  --current-text-transform: var(--theme-heading-3-text-transform);
+  --current-color: var(--theme-heading-3-color); }
 
 h4, .h4 {
   --font-size: var(--theme-heading-4-font-size);
@@ -799,7 +802,8 @@ h4, .h4 {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 h5, .h5 {
   --font-size: var(--theme-heading-5-font-size);
@@ -809,7 +813,8 @@ h5, .h5 {
   --current-font-style: var(--theme-heading-5-font-style);
   --current-line-height: var(--theme-heading-5-line-height);
   --current-letter-spacing: var(--theme-heading-5-letter-spacing);
-  --current-text-transform: var(--theme-heading-5-text-transform); }
+  --current-text-transform: var(--theme-heading-5-text-transform);
+  --current-color: var(--theme-heading-5-color); }
 
 h6, .h6 {
   --font-size: var(--theme-heading-6-font-size);
@@ -819,7 +824,8 @@ h6, .h6 {
   --current-font-style: var(--theme-heading-6-font-style);
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
-  --current-text-transform: var(--theme-heading-6-text-transform); }
+  --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color); }
 
 em,
 i,
@@ -1454,6 +1460,7 @@ table {
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
   --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color);
   --font-size: calc(var(--theme-header-logo-height-setting) * 1.8);
   --current-line-height: 1; }
   @media not screen and (min-width: 768px) {
@@ -2044,6 +2051,7 @@ label.subscribe-label.subscribe-label {
   --current-line-height: var(--theme-heading-6-line-height);
   --current-letter-spacing: var(--theme-heading-6-letter-spacing);
   --current-text-transform: var(--theme-heading-6-text-transform);
+  --current-color: var(--theme-heading-6-color);
   opacity: .6; }
 
 .comment__metadata {
@@ -2268,7 +2276,8 @@ span.page-numbers {
   --current-font-style: var(--theme-heading-4-font-style);
   --current-line-height: var(--theme-heading-4-line-height);
   --current-letter-spacing: var(--theme-heading-4-letter-spacing);
-  --current-text-transform: var(--theme-heading-4-text-transform); }
+  --current-text-transform: var(--theme-heading-4-text-transform);
+  --current-color: var(--theme-heading-4-color); }
 
 .post-navigation__post-title,
 .post-navigation__link-label {


### PR DESCRIPTION
The default font-size picker in the WordPress block editor is disabled [in Rosa2](https://github.com/pixelgrade/rosa2/blob/main/functions.php#L95)

The current font-size picker is added [in Nova Blocks](https://github.com/pixelgrade/nova-blocks/blob/master/packages/block-editor/src/hooks/with-font-size-picker/index.js#L32-L37) to a specific set of blocks. It works in the same way styles do... meaning that the `Additional CSS class(es)` field is update automatically when the font size picker changes. 

We could do this though block support API, and even hide the classes from the user, but I feel it isn't necessary as I can't see any major drawbacks for the moment.