### PR TITLE
Fix fatal TypeError in Tonesque on PHP 8.x for unreadable featured images

### DIFF
--- a/inc/classes/class-tonesque.php
+++ b/inc/classes/class-tonesque.php
@@ -55,6 +55,14 @@ class Tonesque {
 				return false;
 		}
 
+		// Bail if the image could not be loaded. On PHP 8.x the imagecreatefrom*()
+		// functions return false (instead of a GD object) for missing, broken, or
+		// unreadable images, and passing that to imagesy() in grab_color() throws a
+		// fatal TypeError under PHP 8's stricter typing.
+		if ( false === $img ) {
+			return false;
+		}
+
 		// Finds dominant color
 		$color = self::grab_color( $img, $points );
 		// Passes value to Color class


### PR DESCRIPTION
## What

Adds a guard in `Tonesque::color()` so a failed image load (`imagecreatefrom*()` returning `false`) short-circuits instead of being passed into `grab_color()` → `imagesy()`.

## Why

On PHP 8.x, `imagecreatefromgif/png/jpeg()` return `false` (not a GD object) for missing, broken, or unreadable images. That `false` flowed straight into `imagesy()`, which throws a fatal `TypeError` under PHP 8's stricter typing — taking down any page that renders a portfolio/Supernova card with a bad featured image. Confirmed in production on Anima 2.0.16 / WP 7.0 / PHP 8.5.6.

```
Uncaught TypeError: imagesy(): Argument #1 ($image) must be of type GdImage, false given
in inc/classes/class-tonesque.php:76
```

## Safety

`false` is already a valid return from `color()` (the `default:` case returns it) and callers (`anima_extract_color_from_attachment()`) handle it. This only short-circuits the path that currently fatals, so there is no behavior change for healthy images.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)